### PR TITLE
Adding question proposal summary file for 2024 survey

### DIFF
--- a/2024/questions.md
+++ b/2024/questions.md
@@ -1,0 +1,350 @@
+<style type="text/css">
+    ol ol { list-style-type: lower-alpha; }
+</style>
+
+# Questions 2024
+This document lists the questions intended to be shared with the Community for the survey 2024. The idea is to gauge a discussion with the Community around which are the right questions to ask this year.
+
+## Change log 2024 questions compared to 2023
+|#|Question|Change|Link to Discussion|
+|:--------:|--------|-------|-------|
+|1|How many years of experience do you have writing/deploying software?|change options|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/5)|
+|2|How many years of experience do you have writing software using a functional programming stack?|change options|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/5)|
+|3|How would you rate your sentiment towards functional programming?|delete|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/5)|
+|4|Do you work on Cardano as a hobby or professionally?|What is your most awaited feature when it comes to Cardano’s smart contracts||
+|5|Which language(s) are you fluent in?|change wording|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/6)|
+|6|Which best describes your current profession?|change options||
+|7|What is your main development environment?|:heavy_check_mark:||
+|8|Which programming language(s) are you proficient in?|:heavy_check_mark:||
+|9|How would you rate your technical understanding of Cardano?|:heavy_check_mark:||
+|10|Are you a certified Plutus Pioneer?|delete|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/7)|
+|11|What do you use (or plan to use) for writing Plutus script validators / smart contracts?|:heavy_check_mark:||
+|12|What language(s) do you use (or plan to use) for writing off-chain code?|:heavy_check_mark:||
+|13|How satisfied are you with the current state of the smart contract ecosystem?|:heavy_check_mark:||
+|14|What is your most awaited feature when it comes to Cardano’s smart contracts?|:heavy_check_mark:||
+|15|Which libraries do you use in your projects?|:heavy_check_mark:||
+|16|How satisfied are you with the current state of the Cardano libraries listed in the previous question?|delete|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/8)|
+|17|Which services do you use in your projects?|:heavy_check_mark:||
+|18|How satisfied are you with the current state of the Cardano services listed in the previous question?|delete|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/8)|
+|19|Which hosted service(s)/platform(s) do you use in your projects?|:heavy_check_mark:||
+|20|How satisfied are you with the current state of the Cardano hosted services/platforms listed in the previous question?|delete|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/8)|
+|21|Which command-line tool(s) do you use in your projects?|:heavy_check_mark:||
+|22|How satisfied are you with the current state of the Cardano command-line tools listed in the previous question?|delete|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/8)|
+|23|How do you manage deployment to your infrastructure?|:heavy_check_mark:||
+|24|How would you rather consume software?|:heavy_check_mark:||
+|25|What do you think is the greatest asset of Cardano’s developer ecosystem?|:heavy_check_mark:||
+|26|What do you think is the most painful point of Cardano's developer ecosystem?|:heavy_check_mark:||
+|27|Select any statement that applies to you․|:heavy_check_mark:||
+|28|Where do you usually seek help on technical issues?|:heavy_check_mark:||
+|29|Where/how do you look for technical details on Cardano?|:heavy_check_mark:||
+|30|On average, how satisfied are you with the technical answers/details you find in documentation and within the community?|:heavy_check_mark:||
+
+## Questions from 2023
+List of questions from the 2023 survey:
+
+1. **How many years of experience do you have writing/deploying software?**
+    1. I never wrote or deployed software
+    2. ~~Less than 1 year~~ Newcomers, < 1 year
+    3. ~~Between 1 and 3 years~~ Emerging, 1-2 years
+    4. ~~Between 3 and 10 years~~ Established, 2+ years
+    5. ~~Over 10 years~~ Seasoned, 7+ years
+
+2. **How many years of experience do you have writing software using a functional programming stack?**
+    1. I have never used functional programming
+    2. ~~Less than 1 year~~ Newcomers, < 1 year
+    3. ~~Between 1 and 3 years~~ Emerging, 1-2 years
+    4. ~~Between 3 and 10 years~~ Established, 2+ years
+    5. ~~Over 10 years~~ Seasoned, 7+ years
+
+3. **How many years of experience do you have writing/deploying software in crypto?**
+    1. I never wrote or deployed software in crypto
+    2. ~~Less than 1 year~~ Newcomers, < 1 year
+    3. ~~Between 1 and 3 years~~ Emerging, 1-2 years
+    4. ~~Between 3 and 10 years~~ Established, 2+ years
+    5. ~~Over 10 years~~ Seasoned, 7+ years
+
+4. **Did you ever contribute, or wrote and deployed software in other crypto ecosystems?**
+    1. I only ever worked in the Cardano ecosystem
+    2. I have worked in other crypto ecosystems before but moved to Cardano
+    3. Besides Cardano, I work in parallel also in other crypto ecosystems at the moment
+
+5. **In case you have developed or deployed or still develop and deploy software in other crypto ecosystems, which have this been?**
+    1. Bitcoin
+    2. Ethereum and its L2s
+    3. Solana
+    4. Cosmos
+    5. Polkadot
+    6. Algorand
+    7. Avalanche
+    8. Tezos
+    9. ...
+    10. Other
+    11. N/A
+
+6. **Do you work on Cardano as a hobby or professionally?**
+    1. Hobby
+    2. Profession
+    3. Both
+
+7. **Which language(s) do you prefer to consume documentation and educational content in?**
+    1. English
+    2. Spanish
+    3. German
+    4. French
+    5. Vietnamese
+    6. Russian
+    7. Portuguese
+    8. Dutch
+    9. Italian
+    10. Hindi
+    11. Polish
+    12. Japanese
+    13. Arabic
+    14. Indonesian
+    15. Greek
+    16. Ukrainian
+    17. Other
+
+8. **Which best describes your current profession?**
+    1. Software engineer
+    2. Founder/~~executive officer~~C-Suite
+    3. System architect
+    4. Web developer
+    5. Project manager
+    6. R&D engineer
+    7. Student/apprentice
+    8. System administrator
+    9. Academic researcher
+    10. Educator
+    11. Trader
+    12. Designer
+    13. Product manager
+    14. Data scientist
+    15. Database administrator
+    16. Financial analyst
+    17. Site reliability engineer and DevOps
+    18. Artist
+    19. Marketing/sales professional
+    20. Other
+
+9. **What is your main development environment?**
+    1. Visual Studio Code
+    2. Vim/NeoVim
+    3. Visual Studio
+    4. IntelliJ
+    5. Emacs
+    6. JetBrains
+    7. Notepad++
+    8. Atom
+    9. Sublime Text
+    10. XCode
+    11. Other
+
+10. **Which programming language(s) are you proficient in?**
+    1. JavaScript
+    2. TypeScript
+    3. Python
+    4. Haskell
+    5. Bash
+    6. Rust
+    7. Java
+    8. Aiken
+    9. C++
+    10. C
+    11. PHP
+    12. C#
+    13. Go
+    14. Nix
+    15. Solidity
+    16. Kotlin
+    17. Ruby
+    18. Elm
+    19. Scala
+    20. Swift
+    21. Helios
+    22. Elixir
+    23. Other
+
+11. **How would you rate your technical understanding of Cardano?**
+    - Scale from 1 (Rookie) to 10 (Expert)
+
+12. **What do you use (or plan to use) for writing Plutus script validators / smart contracts?**
+    1. Aiken
+    2. Haskell/Plutus-tx
+    3. Marlowe
+    4. Plutarch
+    5. Plu-ts
+    6. Helios
+    7. OpShin
+    8. Solidity (with Milkomeda)
+    9. Pluto
+    10. Scalus
+    11. N/A
+    12. Other
+
+13. **What language(s) do you use (or plan to use) for writing off-chain code?**
+    1. TypeScript
+    2. JavaScript
+    3. Haskell
+    4. Rust
+    5. Python
+    6. Java
+    7. Go
+    8. C#
+    9. PureScript
+    10. C++
+    11. Kotlin
+    12. Other
+
+14. **How satisfied are you with the current state of the smart contract ecosystem?**
+    - Scale from 1 (Unsatisfied) to 10 (Pleased)
+
+15. **What is your most awaited feature when it comes to Cardano’s smart contracts?**
+    - Open Question
+
+16. **Which libraries do you use in your projects?**
+    1. blockfrost-sdk (blockfrost)
+    2. Lucid (BerryPool)
+    3. cardano-api (input-output-hk)
+    4. cardano-serialization-lib (emurgo)
+    5. Mesh.js (MartifyLabs)
+    6. Ogmios' client (CardanoSolutions)
+    7. cardano-multiplatform-library (dcSpark)
+    8. Pallas (txpipe)
+    9. cardano-js-sdk (input-output-hk)
+    10. cardano-transaction-lib (plutonomicon)
+    11. Koios' client (cardano-community)
+    12. yaci or cardano-client-lib (bloxbean)
+    13. Helios (Hyperion-BT)
+    14. cardano-wallet-connector (dynamicstrategies)
+    15. Gouroboros (BlinkLabs)
+    16. PyCardano (cffls)
+    17. cardano-python (emesik)
+    18. TyphonJS (StricaHQ)
+    19. cardanocli-js (shareslake)
+    20. cardanosharp-wallet (CardanoSharp)
+    21. Ouroboros-network-js (StricaHQ)
+    22. toolkit-for-cardano (SundaeSwap-finance)
+    23. Other
+
+17. **Which services do you use in your projects?**
+    1. cardano-db-sync (input-output-hk)
+    2. Ogmios (CardanoSolutions)
+    3. Kupo (CardanoSolutions)
+    4. cardano-wallet (cardano-foundation)
+    5. Oura (TxPipe)
+    6. Scrolls (TxPipe)
+    7. cardano-transaction-lib (Plutonomicon)
+    8. Hydra (input-output-hk)
+    9. cardano-graphql (cardano-foundation)
+    10. Mithril (input-output-hk)
+    11. Atlas (GeniusYield)
+    12. cardano-metadata-oracle (5Binaries)
+    13. Offchain-metadata-tools (input-output-hk)
+    14. SMASH (input-output-hk)
+    15. cardano-rosetta (cardano-foundation)
+    16. DAB (cardano-foundation)
+    17. None directly
+    18. Other
+
+18. **Which hosted service(s)/platform(s) do you use in your projects?**
+    1. Blockfrost (5Binaries)
+    2. CardanoScan (StricaHQ)
+    3. CExplorer (Cardanians)
+    4. Demeter.run (TxPipe)
+    5. Token registry (cardano-foundation)
+    6. Handle (AdaHandle)
+    7. Koios (Koios)
+    8. Maestro (GoMaestro)
+    9. NMKR (NMKR)
+    10. Freeloaderz (FreeLoaderz)
+    11. Dandelion (Gimbalabs)
+    12. N/A
+    13. Other
+
+19. **Which command-line tool(s) do you use in your projects?**
+    1. cardano-cli (input-output-hk)
+    2. aiken (aiken-lang)
+    3. cardano-addresses (input-output-hk)
+    4. bech32 (input-output-hk)
+    5. cncli (cardano-community)
+    6. offchain-metadata-tools (input-output-hk)
+    7. helios (Hyperion-BT)
+    8. jamb (iburzynski)
+    9. yaci (bloxbean)
+    10. N/A
+    11. Other
+
+20. **How do you manage deployment to your infrastructure?**
+    1. Docker
+    2. Bash scripts
+    3. Nix/NixOS
+    4. Kubernetes
+    5. Demeter.run
+    6. Terraform
+    7. Ansible
+    8. AWS
+    9. Vercel
+    10. N/A
+    11. Other
+
+21. **How would you rather consume software?**
+    1. Language package manager (e.g. yarn, pip, cargo, cabal, etc.)
+    2. Docker
+    3. OS package manager (e.g. apt, rpm, homebrew, chocolatey, etc.)
+    4. Source code + build instructions
+    5. Nix
+    6. Downloadable static executable (amd)
+    7. Downloadable static executable (arm)
+    8. Other
+
+22. **What improvements or additional features and language support are missing in Cardano's offchain infrastructure like libraries, services and hosted services?**
+    - Open Question
+
+23. **What do you think is the greatest asset of Cardano’s developer ecosystem?**
+    - Open Question
+
+24. **What do you think is the most painful point of Cardano's developer ecosystem?**
+    - Open Question
+
+25. **Select any statement that applies to you․**
+    1. I have never heard of the Cardano Improvement Proposals (CIPs)
+    2. I have read and used a CIP
+    3. I have participated in conversations or reviews related to a CIP
+    4. I have written or co-written a CIP
+
+26. **Where do you usually seek help on technical issues?**
+    1. Discord servers
+    2. GitHub discussions/issues
+    3. Friends/colleagues/community members
+    4. Cardano StackExchange
+    5. Cardano forum
+    6. Telegram groups
+    7. Twitter/X
+    8. Reddit(r/Cardano, r/CardanoDevelopers)
+    9. Other
+
+27. **Where/how do you look for technical details on Cardano?**
+    1. Source code
+    2. Cardano docs (https://docs.cardano.org/)
+    3. Cardano's developer portal (https://developers.cardano.org/)
+    4. Blog or website articles & guides
+    5. Discord servers
+    6. Friends/colleagues/community members
+    7. Scientific papers/specifications
+    8. (Online) courses (e.g. Plutus Pioneer Program, EMURGO Academy, etc.)
+    9. Cardano forum
+    10. YouTube
+    11. Twitter/X
+    12. Telegram groups
+    13. Reddit (r/Cardano, r/CardanoDevelopers)
+    14. Other
+
+28. **On average, how satisfied are you with the technical answers/details you find in documentation and within the community?**
+    - Scale from 1 (Unsatisfied) to 10 (Pleased)
+
+29. **How satisfied were you with the experience provided by the Cardano Buidler Fest in Toulouse?**
+    - Scale from 1 (Unsatisfied) to 10 (Pleased)
+
+30. **What would you like to improve on the Buidler Fest or do you want to share any other ideas for community engagement in terms of events?**
+    - Open Question

--- a/2024/questions.md
+++ b/2024/questions.md
@@ -1,7 +1,3 @@
-<style type="text/css">
-    ol ol { list-style-type: lower-alpha; }
-</style>
-
 # Questions 2024
 This document lists the questions intended to be shared with the Community for the survey 2024. The idea is to gauge a discussion with the Community around which are the right questions to ask this year.
 
@@ -11,7 +7,7 @@ This document lists the questions intended to be shared with the Community for t
 |1|How many years of experience do you have writing/deploying software?|change options|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/5)|
 |2|How many years of experience do you have writing software using a functional programming stack?|change options|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/5)|
 |3|How would you rate your sentiment towards functional programming?|delete|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/5)|
-|4|Do you work on Cardano as a hobby or professionally?|What is your most awaited feature when it comes to Cardano’s smart contracts||
+|4|Do you work on Cardano as a hobby or professionally?|:heavy_check_mark:||
 |5|Which language(s) are you fluent in?|change wording|[Link](https://github.com/cardano-foundation/state-of-the-developer-ecosystem/discussions/6)|
 |6|Which best describes your current profession?|change options||
 |7|What is your main development environment?|:heavy_check_mark:||
@@ -39,8 +35,8 @@ This document lists the questions intended to be shared with the Community for t
 |29|Where/how do you look for technical details on Cardano?|:heavy_check_mark:||
 |30|On average, how satisfied are you with the technical answers/details you find in documentation and within the community?|:heavy_check_mark:||
 
-## Questions from 2023
-List of questions from the 2023 survey:
+## Proposed Questions for 2024
+List of questions proposed for the 2024 survey:
 
 1. **How many years of experience do you have writing/deploying software?**
     1. I never wrote or deployed software


### PR DESCRIPTION
Hey,

I created a markdown that summarizes the discussions I opened, tracks kind of a manual change lock and lists the questions I would propose to ask in the 2024 survey based on the discussions opened. Can be adapted accordingly based on discussion feedback.